### PR TITLE
fix: dont use time.Time

### DIFF
--- a/kv2.go
+++ b/kv2.go
@@ -7,17 +7,16 @@ import (
 	"context"
 	"net/http"
 	"path"
-	"time"
 )
 
 // KV2Secret is a secret from a KV2 engine
 type KV2Secret struct {
 	Metadata struct {
 		// CreatedTime is when this secret was created
-		CreatedTime time.Time `json:"created_time"`
+		CreatedTime string `json:"created_time"`
 
 		// DeletionTime is when this secret was destroyed
-		DeletionTime time.Time `json:"deletion_time"`
+		DeletionTime string `json:"deletion_time"`
 
 		// Destroyed denotes if this secret was destroyed or not
 		Destroyed bool `json:"destroyed"`


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Title says, it does. Doesn't appear to work with older Vault instances:

```bash
ERRO[0000] failed to run: failed to setup image pull secret: failed to read image pull secret from Vault: failed to decode response: parsing time "\"\"" as "\"2006-01-02T15:04:05Z07:00\"": cannot parse "\"" as "2006"
```


<!--- Block(jiraPrefix) --->
## Jira ID

[DTSS-0]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!--- Block(custom) -->
<!--- EndBlock(custom) -->
