### PR TITLE
fix: remove token-only, we really want json

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -33,7 +33,6 @@ func EnsureLoggedIn(ctx context.Context, log logrus.FieldLogger, b *box.Config) 
 		//nolint:gosec // Why: passing in the auth method and vault address
 		cmd := exec.CommandContext(ctx, "vault",
 			"login",
-			"-token-only",
 			"-format",
 			"json",
 			"-method",


### PR DESCRIPTION
vault versions higher than v1.11.2 fixed an issue with conflicting arguments like combining json and token only.

