### PR TITLE
fix: remove trailing slash in DevelopmentAddress

### DIFF
--- a/cli/login.go
+++ b/cli/login.go
@@ -21,7 +21,7 @@ const (
 	ProductionAddress = "https://vault.outreach.cloud"
 
 	// DevelopmentAddress is the Vault address for the development Vault server
-	DevelopmentAddress = "https://vault-dev.outreach.cloud/"
+	DevelopmentAddress = "https://vault-dev.outreach.cloud"
 
 	// OidcAuthMethod for using the oidc authentication method to obtain a Vault token
 	OidcAuthMethod = "oidc"


### PR DESCRIPTION
## What this PR does / why we need it
Remove the trailing slash in `DevelopmentAddress` so that it can be used with the `EnsureLoggedIn` and `IsLoggedIn` functions.